### PR TITLE
Update candidate version to work with brew 0.9.2's info command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ contents, so if you’ve already got stuff in there (eg MySQL owned by a
 `mysql` user) you’ll need to be a touch more careful. This is a
 recommendation from the Homebrew
 
+brew does not like installing packages as root and will refuse to do so.
+We therefore need a nominated non-root user to install stuff as.
+
+ node["homebrew"]["run_as"] = "leftbrained"
+
+The above attribute must be set to a valid username in order to install
+packages.  If the attribute isn't set on the node an exception with be thrown.
+
 ## Platform
 
 * Mac OS X (10.6+)


### PR DESCRIPTION
candidate_version relies on an awk expression that now works with brew 0.9.2

candidate_version parses the output of brew info with a regex incorporating a whitespace.  

awk assumes that brew info will format output as:

`tmux stable 1.6, HEAD`

However, brew 0.9.2 formats as

`tmux: stable 1.6, HEAD`

The old awk regex couldn't pick up the 0.9.2 formatting and would always no available packages.

New awk regex is sensitive to both whitespace and colon formatted info.

[See the change in brew here](https://github.com/mxcl/homebrew/commit/94d0f237f1af173872757b6716afa7bb58da8957)
