### PR TITLE
fix how we check whether a command failed

### DIFF
--- a/libraries/homebrew_package.rb
+++ b/libraries/homebrew_package.rb
@@ -63,7 +63,7 @@ class Chef
               raise Chef::Exceptions::Package, "Could not read from STDOUT on command: #{command}\nException: #{e.inspect}"
             end
           end
-          unless (0..1).include? status.exitstatus
+          unless status.success?
             raise Chef::Exceptions::Package, "#{command} failed - #{status.inspect}"
           end
           output


### PR DESCRIPTION
I can't say for sure, but I believe that accepting an exit status of 1 as success is an artifact of this code's extraction from the macports provider. Certainly in its current form chef will happily chug along after a formula fails to install. This commit fixes that.
