### PR TITLE
Parse `brew info` properly to get the candidate version

### DIFF
--- a/libraries/homebrew_package.rb
+++ b/libraries/homebrew_package.rb
@@ -44,7 +44,7 @@ class Chef
         end
 
         def candidate_version
-          get_version_from_command("brew info #{@new_resource.package_name} | awk '/^#{@new_resource.package_name} / { print $2 }'")
+          get_version_from_command("brew info #{@new_resource.package_name} | awk -F'[, ]' '/^#{@new_resource.package_name}:/ { print $3 }'")
         end
 
         def get_version_from_command(command)


### PR DESCRIPTION
Fix for http://tickets.opscode.com/browse/COOK-1562
