### PR TITLE
Solution for ticket COOK-1821

### DIFF
--- a/libraries/homebrew_package.rb
+++ b/libraries/homebrew_package.rb
@@ -51,7 +51,7 @@ class Chef
 
         def candidate_version
           pkg = get_version_from_formula
-          pkg.stable.version || pkg.version
+          pkg.stable.version.to_s || pkg.version.to_s
         end
 
         def get_version_from_command(command)


### PR DESCRIPTION
Forcing candidate_version to return a string to prevent version tests that require String from failing within the core provider code.
