### PR TITLE
Fix for COOK-1843: Encoding::InvalidByteSequence error uploading with knife 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ remains licensed under the Apache License version 2.
 ## Prerequisites
 
 In order for this recipe to work, your userid must own `/usr/local`.
-This is outside the scope of the cookbook because it’s anticipated
-that you’ll run the cookbook as your own user, not root and you’d have
+This is outside the scope of the cookbook because it's anticipated
+that you'll run the cookbook as your own user, not root and you'd have
 to be root to take ownership of the directory. Easiest way to get
 started:
 
     sudo chown -R `whoami`:staff /usr/local
 
 Bear in mind that this will take ownership of the entire folder and its
-contents, so if you’ve already got stuff in there (eg MySQL owned by a
-`mysql` user) you’ll need to be a touch more careful. This is a
+contents, so if you've already got stuff in there (eg MySQL owned by a
+`mysql` user) you'll need to be a touch more careful. This is a
 recommendation from the Homebrew
 
 ## Platform
@@ -106,14 +106,14 @@ Author:: Joshua Timberman (<joshua@opscode.com>)
 Copyright:: 2011, Graeme Mathieson
 Copyright:: 2012, Opscode, Inc <legal@opscode.com>
 
-Licensed under the Apache License, Version 2.0 (the “License”); you may
+Licensed under the Apache License, Version 2.0 (the "License"); you may
 not use this file except in compliance with the License. You may obtain
 a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an “AS IS” BASIS,
+distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.


### PR DESCRIPTION
Replace non-ASCII characters (pretty quotes) in README.md with their ASCII equivalents, to work around COOK-1843.
