### PR TITLE
[COOK-1539] Homebrew won't run as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ contents, so if you’ve already got stuff in there (eg MySQL owned by a
 `mysql` user) you’ll need to be a touch more careful. This is a
 recommendation from the Homebrew
 
+brew does not like installing packages as root and will refuse to do so.
+We therefore need a nominated non-root user to install stuff as.
+
+ node["homebrew"]["run_as"] = "leftbrained"
+
+The above attribute must be set to a valid username in order to install
+packages.  If the attribute isn't set on the node an exception with be thrown.
+
 ## Platform
 
 * Mac OS X (10.6+)


### PR DESCRIPTION
Running chef-client as root results in brew running as root. As of Brew 0.9.2, brew will refuse to run as root. 

```
$ sudo brew install nginx
Cowardly refusing to `sudo brew install'
```

When Chef runs any brew-backed installs will silently fail.

The package resource doesn't have a user attribute and, IMHO, it would be odd if it did seeing as brew is the only package manager that runs as non-root. My current workaround is to give brew a nominated user to run as:

```
node["homebrew"]["run_as"] = "leftbrained"
```
