### PR TITLE
Fix Conventional Taps Name

### DIFF
--- a/providers/tap.rb
+++ b/providers/tap.rb
@@ -1,6 +1,6 @@
 def load_current_resource
   @tap = Chef::Resource::HomebrewTap.new(new_resource.name)
-  tap_dir = @tap.name.gsub('/', '-')
+  tap_dir = @tap.name.gsub('homebrew-', '').gsub('/', '-')
 
   Chef::Log.debug("Checking whether we've already tapped #{new_resource.name}")
   if ::File.directory?("/usr/local/Library/Taps/#{tap_dir}")


### PR DESCRIPTION
Taps which come from homebrew do not have `homebrew-` in the title, but ones from other repositories typically do (eg `josegonzalez/homebrew-php`, `phinze/homebrew-cask`).  However those taps would be installed in directories called `josegonzalez-php` and `phinze-cask` respectively.

The correct conversion for those would be to remove the `homebrew-` part first, then convert the `/` to a `-`.
