### PR TITLE
[COOK-3825] homebrew_package needs $HOME set

### DIFF
--- a/libraries/homebrew_package.rb
+++ b/libraries/homebrew_package.rb
@@ -91,8 +91,11 @@ class Chef
         end
 
         def get_response_from_command(command)
+          require 'etc'
+          home_dir = Etc.getpwnam(homebrew_owner).dir
+
           Chef::Log.debug "Executing '#{command}' as #{homebrew_owner}"
-          output = shell_out!(command, :user => homebrew_owner)
+          output = shell_out!(command, :user => homebrew_owner, :environment => {'HOME' => home_dir})
           output.stdout
         end
       end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3825

When running chef solo/client as root, brew package doesn't get the $HOME environment variable - which means package installs fail when trying to log.

See this gist for error output: https://gist.github.com/walkah/d56d4b52ef893a36aa61

This PR explicitly sets $HOME for homebrew_owner during shell_out.
