### PR TITLE
Support for "homebrew-"-named repos

### DIFF
--- a/providers/tap.rb
+++ b/providers/tap.rb
@@ -21,7 +21,7 @@
 
 def load_current_resource
   @tap = Chef::Resource::HomebrewTap.new(new_resource.name)
-  tap_dir = @tap.name.gsub('/', '-')
+  tap_dir = @tap.name.gsub('/homebrew-', '-').gsub('/', '-')
 
   Chef::Log.debug("Checking whether we've already tapped #{new_resource.name}")
   if ::File.directory?("/usr/local/Library/Taps/#{tap_dir}")


### PR DESCRIPTION
Homebrew does some magic when the git repo name starts with "homebrew-".

All of them on my machine (not even digging :trollface:):
- Homebrew/homebrew-dupes
- Homebrew/homebrew-versions
- phinze/homebrew-cask
- pivotal/homebrew-tap
