### PR TITLE
Updates homebrew_go install script source url

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,7 +27,7 @@ owner = homebrew_owner
 Chef::Log.debug("Homebrew owner is '#{homebrew_owner}'")
 
 remote_file homebrew_go do
-  source "https://raw.github.com/mxcl/homebrew/go"
+  source "https://raw.github.com/mxcl/homebrew/go/install"
   mode 00755
 end
 


### PR DESCRIPTION
The previous url was getting a 301 and redirecting to the GitHub web UI instead of the raw source.
