### PR TITLE
[COOK-4566] Guard against "HEAD only" formulae

### DIFF
--- a/libraries/homebrew_package.rb
+++ b/libraries/homebrew_package.rb
@@ -89,7 +89,7 @@ class Chef
           require 'global'
           require 'cmd/info'
 
-          Formula.factory new_resource.package_name
+          Formula[new_resource.package_name]
         end
 
         def get_response_from_command(command)


### PR DESCRIPTION
Some formulae are "HEAD only". They are in a [separate repository](https://github.com/Homebrew/homebrew-headonly) but can easily be added using `brew tap homebrew/headonly`. This solves an issue where `Formula#stable` returns `nil` for these formulae.

Also replaces the deprecated `Formula.factory` method with `Formula[]`.
