### PR TITLE
Fix tap directory location

### DIFF
--- a/providers/tap.rb
+++ b/providers/tap.rb
@@ -21,7 +21,7 @@
 
 def load_current_resource
   @tap = Chef::Resource::HomebrewTap.new(new_resource.name)
-  tap_dir = @tap.name.gsub('/', '-')
+  tap_dir = @tap.name.gsub('/', '/homebrew-')
 
   Chef::Log.debug("Checking whether we've already tapped #{new_resource.name}")
   if ::File.directory?("/usr/local/Library/Taps/#{tap_dir}")


### PR DESCRIPTION
Since https://github.com/Homebrew/homebrew/pull/28203 the location for
homebrew taps has changed to
/usr/local/Homebrew/Taps/username/homebrew-tapname. This change both removes
the slash to dash conversation, and also adds the homebrew- prefix to the
tapname.
