### PR TITLE
Call brew without RUBYOPT environment variable

### DIFF
--- a/libraries/homebrew_package.rb
+++ b/libraries/homebrew_package.rb
@@ -97,7 +97,7 @@ class Chef
           home_dir = Etc.getpwnam(homebrew_owner).dir
 
           Chef::Log.debug "Executing '#{command}' as #{homebrew_owner}"
-          output = shell_out!(command, :user => homebrew_owner, :environment => { 'HOME' => home_dir })
+          output = shell_out!(command, :user => homebrew_owner, :environment => { 'HOME' => home_dir, 'RUBYOPT' => nil })
           output.stdout
         end
       end


### PR DESCRIPTION
If you run chef via `bundle exec` from a project that uses a non-system version of ruby, then you can run into an issue where bundler gets loaded against the system ruby that brew uses.

This causes problems when, for example, you have code in your Gemfile that doesn't work in Ruby 1.8 and you are running OS X Mountain Lion which uses Ruby 1.8 as its system ruby.
