### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ And then install the homebrew cask package before using this LWRP.
 
     homebrew_cask "google-chrome"
 
-    homebrew_tap "google-chrome" do
+    homebrew_cask "google-chrome" do
       action :uncask
     end
 


### PR DESCRIPTION
This example referenced the wrong LWRP
