### PR TITLE
Make the file_cache_path directory configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,3 +20,4 @@
 #
 
 default['homebrew']['owner'] = nil
+default['homebrew']['file_cache_path'] = Chef::Config[:file_cache_path]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,7 @@
 
 extend(Homebrew::Mixin)
 
-homebrew_go = "#{Chef::Config[:file_cache_path]}/homebrew_go"
+homebrew_go = "#{node[:homebrew][:file_cache_path]}/homebrew_go"
 owner = homebrew_owner
 
 Chef::Log.debug("Homebrew owner is '#{homebrew_owner}'")


### PR DESCRIPTION
When the cookbook is running as root, chef sets the chef directory (top
directory of cache folder) to 700. When the homebrew cookbook is
executed the homebrew_go script is downloaded to chef cache. The file
can't be executed by the non root owner because the chef top level
directory is not readable by the user:

$ sudo ls -ld chef chef/cache chef/cache/homebrew_go
drwx------  5 root  root   170 May 28 11:53 chef
drwxr-xr-x  5 root  root   170 May 28 11:53 chef/cache
-rwxr-xr-x  1 root  root  7231 May 28 11:53 chef/cache/homebrew_go

In general it might be a better idea to download the homebrew_go script
to /tmp and only download it if homebrew is not installed. But as a
first fix this patch makes the file_cache_path configurable over an
attribute.
