### PR TITLE
Add example of Homebrew package options to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ homebrew_package 'mysql'
 package 'mysql' do
   provider Chef::Provider::Package::Homebrew
 end
+
+package 'wireshark' do
+  options '--with-qt --devel'
+end
 ```
 
 ### homebrew\_tap


### PR DESCRIPTION
This cookbook is awesome, but I was wondering if it supported options to individual packages. After looking around the source, I was pleasantly surprised to find that it does. This commit adds an example of package options to the README. Feel free to correct or change the example— this was just my use case.

The contribution guidelines seem to be out-of-date— please just let me know what I need to do.

Thanks!
