### PR TITLE
Add test kitchen support, with cavaets

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,21 @@
+---
+driver:
+  name: vagrant
+  customize:
+    memory: 1024
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  # To run test-kitchen for OS X, create a box for 10.9, and add it to vagrant. See for example,
+  # https://github.com/timsutton/osx-vm-templates
+  # https://github.com/opscode/bento/blob/master/packer/macosx-10.9.json
+  - name: macosx-10.9
+
+suites:
+  - name: default
+    run_list:
+      - recipe[build-essential]
+      - recipe[homebrew::default]
+    attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,5 @@
+source 'https://supermarket.getchef.com'
+metadata
+
+cookbook 'build-essential'
+cookbook 'test', :path => 'test/fixtures/cookbooks/test'

--- a/test/integration/cookbooks/test/README.md
+++ b/test/integration/cookbooks/test/README.md
@@ -1,0 +1,4 @@
+# test
+
+TODO: Enter the cookbook description here.
+

--- a/test/integration/cookbooks/test/metadata.rb
+++ b/test/integration/cookbooks/test/metadata.rb
@@ -1,0 +1,8 @@
+name             'test'
+maintainer       ''
+maintainer_email ''
+license          ''
+description      'Installs/Configures test'
+long_description 'Installs/Configures test'
+version          '0.1.0'
+

--- a/test/integration/cookbooks/test/recipes/default.rb
+++ b/test/integration/cookbooks/test/recipes/default.rb
@@ -1,0 +1,2 @@
+# redis is small and installs fast.
+package 'redis'


### PR DESCRIPTION
This commit adds initial test kitchen support to this cookbook.
- It assumes that those who wish to use test-kitchen have a box named
  `macosx-10.9` already built and added on their local workstation.
  Said box should not have anything installed - it should be a base OS.
- build-essential is added via a Berksfile and included before
  `homebrew`, as it's required by homebrew (the project), but not by
  homebrew (this cookbook), since users may wish to install XCode on
  their own systems via the App Store.
