### PR TITLE
update url per homebrew error

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,7 +27,7 @@ owner = homebrew_owner
 Chef::Log.debug("Homebrew owner is '#{homebrew_owner}'")
 
 remote_file homebrew_go do
-  source 'https://raw.github.com/Homebrew/homebrew/go/install'
+  source 'https://raw.githubusercontent.com/Homebrew/install/master/install'
   mode 00755
 end
 


### PR DESCRIPTION
When running this recipe I get the following output:

``` bash
vagrant-osx-10-9:rocket-fuel-master vagrant$ /var/chef/cache/homebrew_go
Whoops, the Homebrew installer has moved! Please instead run:

ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

Also, please ask wherever you got this link from to update it to the above.
Thanks!
```
