### PR TITLE
Apple m1 opt homebrew support (Fixes #153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This file is used to list changes made in each version of the homebrew cookbook.
 
 ## Unreleased
 
+ - Update to support Apple M1 silicon (arm64) Homebrew install location (`/opt/homebrew`)
+   - Add HomebrewWrapper.repository_path() for homebrew_tap resource idempotency on Apple M1 silicon (arm64)
+   - Add HomebrewWrapper.repository_path() helper for Apple M1 silicon (arm64)
+   - Remove deprecated `--full` option for Homebrew (Breaking upstream CLI change!)
+   - Add chefspec tests for Apple M1 silicon Homebrew path helper
+   - Add InSpec tests for macOS M1 / arm64 and x86_64
+   - Set `use_sudo: false` for InSpec tests to work properly
+   - Convert hardcoded /usr/local to use install_path() for M1 /opt/homebrew support
+   - Add Homebrew.install_path() helper for Apple M1 silicon (arm64)
+
 ## 5.2.2 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@ This file is used to list changes made in each version of the homebrew cookbook.
 
 ## Unreleased
 
- - Update to support Apple M1 silicon (arm64) Homebrew install location (`/opt/homebrew`)
-   - Add HomebrewWrapper.repository_path() for homebrew_tap resource idempotency on Apple M1 silicon (arm64)
-   - Add HomebrewWrapper.repository_path() helper for Apple M1 silicon (arm64)
-   - Remove deprecated `--full` option for Homebrew (Breaking upstream CLI change!)
-   - Add chefspec tests for Apple M1 silicon Homebrew path helper
-   - Add InSpec tests for macOS M1 / arm64 and x86_64
-   - Set `use_sudo: false` for InSpec tests to work properly
-   - Convert hardcoded /usr/local to use install_path() for M1 /opt/homebrew support
-   - Add Homebrew.install_path() helper for Apple M1 silicon (arm64)
+- Update to support Apple M1 silicon (arm64) Homebrew install location (`/opt/homebrew`)
+  - Add HomebrewWrapper.repository_path() for homebrew_tap resource idempotency
+  - Add HomebrewWrapper.repository_path() helper for Apple M1 silicon (arm64)
+  - Remove deprecated `--full` option for Homebrew (Breaking upstream CLI change!)
+  - Add chefspec tests for Apple M1 silicon Homebrew path helper
+  - Add InSpec tests for macOS M1 / arm64 and x86_64
+  - Set `use_sudo: false` for InSpec tests to work properly
+  - Convert hardcoded /usr/local to use install_path() for M1 /opt/homebrew support
+  - Add Homebrew.install_path() helper for Apple M1 silicon (arm64)
 
 ## 5.2.2 - *2021-08-30*
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,6 +1,6 @@
 driver:
   name: vagrant
-  provider: vmware_fusion
+  provider: virtualbox
 
 provisioner:
   name: chef_zero
@@ -10,9 +10,15 @@ verifier:
   sudo: false
 
 platforms:
-  - name: macos-10.12
+  - name: macos-10.15
     driver:
-      box: chef/macos-10.12  # private box in Chef's Atlas account
+      box: trinitronx/macos-catalina-1015-chef  # private box
+      boot_timeout: 1200
+  - name: macos-11.06
+    driver:
+      box: trinitronx/macos-bigsur-1106-chef  # private box
+      boot_timeout: 1200
+
 
 suites:
   - name: default

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -7,6 +7,7 @@ provisioner:
 
 verifier:
   name: inspec
+  sudo: false
 
 platforms:
   - name: macos-10.12

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,6 +1,6 @@
 driver:
   name: vagrant
-  provider: virtualbox
+  provider: vmware_fusion
 
 provisioner:
   name: chef_zero
@@ -10,15 +10,9 @@ verifier:
   sudo: false
 
 platforms:
-  - name: macos-10.15
+  - name: macos-10.12
     driver:
-      box: trinitronx/macos-catalina-1015-chef  # private box
-      boot_timeout: 1200
-  - name: macos-11.06
-    driver:
-      box: trinitronx/macos-bigsur-1106-chef  # private box
-      boot_timeout: 1200
-
+      box: chef/macos-10.12  # private box in Chef's Atlas account
 
 suites:
   - name: default

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -43,6 +43,15 @@ module Homebrew
     end
   end
 
+  def repository_path
+    arm64_test = shell_out('sysctl -n hw.optional.arm64')
+    if arm64_test.stdout.chomp == '1'
+      return '/opt/homebrew'
+    else
+      return '/usr/local/Homebrew'
+    end
+  end
+
   def exist?
     Chef::Log.debug('Checking to see if the homebrew binary exists')
     ::File.exist?("#{HomebrewWrapper.new.install_path}/bin/brew")

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -30,6 +30,10 @@ module Homebrew
   require 'mixlib/shellout'
   include Chef::Mixin::ShellOut
 
+  def self.included(base)
+    base.extend(Homebrew)
+  end
+
   def install_path
     arm64_test = shell_out('sysctl -n hw.optional.arm64')
     if arm64_test.stdout.chomp == '1'
@@ -80,3 +84,7 @@ module Homebrew
     ENV['USER']
   end
 end unless defined?(Homebrew)
+
+class HomebrewWrapper
+  include Homebrew
+end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -37,18 +37,18 @@ module Homebrew
   def install_path
     arm64_test = shell_out('sysctl -n hw.optional.arm64')
     if arm64_test.stdout.chomp == '1'
-      return '/opt/homebrew'
+      '/opt/homebrew'
     else
-      return '/usr/local'
+      '/usr/local'
     end
   end
 
   def repository_path
     arm64_test = shell_out('sysctl -n hw.optional.arm64')
     if arm64_test.stdout.chomp == '1'
-      return '/opt/homebrew'
+      '/opt/homebrew'
     else
-      return '/usr/local/Homebrew'
+      '/usr/local/Homebrew'
     end
   end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -27,6 +27,18 @@ end
 module Homebrew
   extend self
 
+  require 'mixlib/shellout'
+  include Chef::Mixin::ShellOut
+
+  def install_path
+    arm64_test = shell_out('sysctl -n hw.optional.arm64')
+    if arm64_test.stdout.chomp == '1'
+      return '/opt/homebrew'
+    else
+      return '/usr/local'
+    end
+  end
+
   def exist?
     Chef::Log.debug('Checking to see if the homebrew binary exists')
     ::File.exist?('/usr/local/bin/brew')

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -45,7 +45,7 @@ module Homebrew
 
   def exist?
     Chef::Log.debug('Checking to see if the homebrew binary exists')
-    ::File.exist?('/usr/local/bin/brew')
+    ::File.exist?("#{HomebrewWrapper.new.install_path}/bin/brew")
   end
 
   def owner

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -51,6 +51,6 @@ if node['homebrew']['auto-update']
   execute 'update homebrew from github' do
     environment lazy { { 'HOME' => ::Dir.home(Homebrew.owner), 'USER' => Homebrew.owner } }
     user Homebrew.owner
-    command '/usr/local/bin/brew update || true'
+    command lazy { "#{ HomebrewWrapper.new.install_path }/bin/brew update || true" }
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,8 +39,8 @@ end
 execute 'set analytics' do
   environment lazy { { 'HOME' => ::Dir.home(Homebrew.owner), 'USER' => Homebrew.owner } }
   user Homebrew.owner
-  command "/usr/local/bin/brew analytics #{node['homebrew']['enable-analytics'] ? 'on' : 'off'}"
-  only_if { shell_out('/usr/local/bin/brew analytics state', user: Homebrew.owner).stdout.include?('enabled') != node['homebrew']['enable-analytics'] }
+  command lazy { "#{ HomebrewWrapper.new.install_path }/bin/brew analytics #{node['homebrew']['enable-analytics'] ? 'on' : 'off'}" }
+  only_if { shell_out("#{ HomebrewWrapper.new.install_path }/bin/brew analytics state", user: Homebrew.owner).stdout.include?('enabled') != node['homebrew']['enable-analytics'] }
 end
 
 if node['homebrew']['auto-update']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,8 +39,8 @@ end
 execute 'set analytics' do
   environment lazy { { 'HOME' => ::Dir.home(Homebrew.owner), 'USER' => Homebrew.owner } }
   user Homebrew.owner
-  command lazy { "#{ HomebrewWrapper.new.install_path }/bin/brew analytics #{node['homebrew']['enable-analytics'] ? 'on' : 'off'}" }
-  only_if { shell_out("#{ HomebrewWrapper.new.install_path }/bin/brew analytics state", user: Homebrew.owner).stdout.include?('enabled') != node['homebrew']['enable-analytics'] }
+  command lazy { "#{HomebrewWrapper.new.install_path}/bin/brew analytics #{node['homebrew']['enable-analytics'] ? 'on' : 'off'}" }
+  only_if { shell_out("#{HomebrewWrapper.new.install_path}/bin/brew analytics state", user: Homebrew.owner).stdout.include?('enabled') != node['homebrew']['enable-analytics'] }
 end
 
 if node['homebrew']['auto-update']
@@ -51,6 +51,6 @@ if node['homebrew']['auto-update']
   execute 'update homebrew from github' do
     environment lazy { { 'HOME' => ::Dir.home(Homebrew.owner), 'USER' => Homebrew.owner } }
     user Homebrew.owner
-    command lazy { "#{ HomebrewWrapper.new.install_path }/bin/brew update || true" }
+    command lazy { "#{HomebrewWrapper.new.install_path}/bin/brew update || true" }
   end
 end

--- a/recipes/install_taps.rb
+++ b/recipes/install_taps.rb
@@ -26,7 +26,6 @@ node['homebrew']['taps'].each do |tap|
     raise unless tap.key?('tap')
     homebrew_tap tap['tap'] do
       url tap['url'] if tap.key?('url')
-      full tap['full'] if tap.key?('full')
     end
   else
     raise

--- a/resources/cask.rb
+++ b/resources/cask.rb
@@ -24,7 +24,7 @@ chef_version_for_provides '< 14.0' if respond_to?(:chef_version_for_provides)
 property :cask_name, String, regex: %r{^[\w/-]+$}, name_property: true
 property :options, String
 property :install_cask, [true, false], default: true
-property :homebrew_path, String, default: '/usr/local/bin/brew'
+property :homebrew_path, String, default: lazy { "#{ HomebrewWrapper.new.install_path }/bin/brew" }
 property :owner, String, default: lazy { Homebrew.owner } # lazy to prevent breaking compilation on non-macOS platforms
 
 action :install do

--- a/resources/cask.rb
+++ b/resources/cask.rb
@@ -24,7 +24,7 @@ chef_version_for_provides '< 14.0' if respond_to?(:chef_version_for_provides)
 property :cask_name, String, regex: %r{^[\w/-]+$}, name_property: true
 property :options, String
 property :install_cask, [true, false], default: true
-property :homebrew_path, String, default: lazy { "#{ HomebrewWrapper.new.install_path }/bin/brew" }
+property :homebrew_path, String, default: lazy { "#{HomebrewWrapper.new.install_path}/bin/brew" }
 property :owner, String, default: lazy { Homebrew.owner } # lazy to prevent breaking compilation on non-macOS platforms
 
 action :install do

--- a/resources/tap.rb
+++ b/resources/tap.rb
@@ -24,7 +24,7 @@ chef_version_for_provides '< 14.0' if respond_to?(:chef_version_for_provides)
 property :tap_name, String, name_property: true, regex: %r{^[\w-]+(?:\/[\w-]+)+$}
 property :url, String
 property :full, [true, false], default: false
-property :homebrew_path, String, default: lazy { "#{ HomebrewWrapper.new.install_path }/bin/brew" }
+property :homebrew_path, String, default: lazy { "#{HomebrewWrapper.new.install_path}/bin/brew" }
 property :owner, String, default: lazy { Homebrew.owner } # lazy to prevent breaking compilation on non-macOS platforms
 
 action :tap do
@@ -51,5 +51,5 @@ end
 
 def tapped?(name)
   tap_dir = name.gsub('/', '/homebrew-')
-  ::File.directory?("#{ HomebrewWrapper.new.repository_path }/Library/Taps/#{tap_dir}")
+  ::File.directory?("#{HomebrewWrapper.new.repository_path}/Library/Taps/#{tap_dir}")
 end

--- a/resources/tap.rb
+++ b/resources/tap.rb
@@ -51,5 +51,5 @@ end
 
 def tapped?(name)
   tap_dir = name.gsub('/', '/homebrew-')
-  ::File.directory?("#{ HomebrewWrapper.new.install_path }/Homebrew/Library/Taps/#{tap_dir}")
+  ::File.directory?("#{ HomebrewWrapper.new.repository_path }/Library/Taps/#{tap_dir}")
 end

--- a/resources/tap.rb
+++ b/resources/tap.rb
@@ -24,7 +24,7 @@ chef_version_for_provides '< 14.0' if respond_to?(:chef_version_for_provides)
 property :tap_name, String, name_property: true, regex: %r{^[\w-]+(?:\/[\w-]+)+$}
 property :url, String
 property :full, [true, false], default: false
-property :homebrew_path, String, default: '/usr/local/bin/brew'
+property :homebrew_path, String, default: lazy { "#{ HomebrewWrapper.new.install_path }/bin/brew" }
 property :owner, String, default: lazy { Homebrew.owner } # lazy to prevent breaking compilation on non-macOS platforms
 
 action :tap do
@@ -51,5 +51,5 @@ end
 
 def tapped?(name)
   tap_dir = name.gsub('/', '/homebrew-')
-  ::File.directory?("/usr/local/Homebrew/Library/Taps/#{tap_dir}")
+  ::File.directory?("#{ HomebrewWrapper.new.install_path }/Homebrew/Library/Taps/#{tap_dir}")
 end

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -4,6 +4,7 @@ describe 'homebrew::default' do
   before do
     stubs_for_resource('execute[set analytics]') do |resource|
       allow(resource).to receive_shell_out('/usr/local/bin/brew analytics state', user: 'vagrant')
+      allow(resource).to receive_shell_out('/opt/homebrew/bin/brew analytics state', user: 'vagrant')
     end
 
     allow(Homebrew).to receive(:exist?).and_return(true)
@@ -33,7 +34,7 @@ describe 'homebrew::default' do
     end
   end
 
-  context '/usr/local/bin/brew exists' do
+  context 'brew script exists' do
     cached(:chef_run) do
       ChefSpec::SoloRunner.new.converge(described_recipe)
     end

--- a/spec/unit/libraries/homebrew_helpers_spec.rb
+++ b/spec/unit/libraries/homebrew_helpers_spec.rb
@@ -6,6 +6,8 @@ require 'chef/mixin/shell_out'
 describe Homebrew do
   let(:opt_homebrew_path) { '/opt/homebrew' }
   let(:usr_local_homebrew_path) { '/usr/local' }
+  let(:usr_local_repository_path) { '/usr/local/Homebrew' }
+
   let(:shellout) do
     double(command: 'sysctl -n hw.optional.arm64', run_command: nil, error!: nil, stdout: arm64_test_output,
            stderr: stderr, exitstatus: exitstatus, live_stream: nil)
@@ -27,6 +29,13 @@ describe Homebrew do
         expect(dummy_class.new.install_path).to eq opt_homebrew_path
       end
     end
+
+    describe '#repository_path' do
+      let(:dummy_class) { Class.new { include Homebrew } }
+      it 'returns /opt/homebrew path' do
+        expect(dummy_class.new.repository_path).to eq opt_homebrew_path
+      end
+    end
   end
 
   context 'when on Apple Intel Silicon' do
@@ -38,6 +47,13 @@ describe Homebrew do
       let(:dummy_class) { Class.new { include Homebrew } }
       it 'returns /usr/local path' do
         expect(dummy_class.new.install_path).to eq usr_local_homebrew_path
+      end
+    end
+
+    describe '#install_path' do
+      let(:dummy_class) { Class.new { include Homebrew } }
+      it 'returns /usr/local/Homebrew path' do
+        expect(dummy_class.new.repository_path).to eq usr_local_repository_path
       end
     end
   end

--- a/spec/unit/libraries/homebrew_helpers_spec.rb
+++ b/spec/unit/libraries/homebrew_helpers_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'chef/mixin/shell_out'
+
+describe Homebrew do
+  let(:opt_homebrew_path) { '/opt/homebrew' }
+  let(:usr_local_homebrew_path) { '/usr/local' }
+  let(:shellout) do
+    double(command: 'sysctl -n hw.optional.arm64', run_command: nil, error!: nil, stdout: arm64_test_output,
+           stderr: stderr, exitstatus: exitstatus, live_stream: nil)
+  end
+
+  before(:each) do
+    allow(Mixlib::ShellOut).to receive(:new).and_return(shellout)
+    allow(shellout).to receive(:live_stream=).and_return(nil)
+  end
+
+  context 'when on Apple arm64 Silicon' do
+    let(:arm64_test_output) { "1\n" }
+    let(:exitstatus) { 0 }
+    let(:stderr) { double(empty?: true) }
+
+    describe '#install_path' do
+      let(:dummy_class) { Class.new { include Homebrew } }
+      it 'returns /opt/homebrew path' do
+        expect(dummy_class.new.install_path).to eq opt_homebrew_path
+      end
+    end
+  end
+
+  context 'when on Apple Intel Silicon' do
+    let(:arm64_test_output) { '' }
+    let(:exitstatus) { 1 }
+    let(:stderr) { 'sysctl: unknown oid \'hw.optional.arm64\'' }
+
+    describe '#install_path' do
+      let(:dummy_class) { Class.new { include Homebrew } }
+      it 'returns /usr/local path' do
+        expect(dummy_class.new.install_path).to eq usr_local_homebrew_path
+      end
+    end
+  end
+end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,9 +1,45 @@
-describe command('brew info redis --json=v1 | jq ".[].installed[0].installed_on_request"') do
-  its('stdout') { should match('true') }
+# Check both x86_64 and arm64 locations for brew
+# Depending on shell setup in the box:
+# InSpec commands want a full path, but this depends on arch + platform_version
+# macOS default shell may be /bin/bash or /bin/zsh ... back to basics: /bin/sh
+describe command('/bin/sh -c "PATH=/opt/homebrew/bin:/usr/local/bin:$PATH  brew --version"') do
+  its('stdout') { should match('^Homebrew.*$') }
 end
 
-describe file('/usr/local/Caskroom/caffeine') do
+brew_prefix = command('/bin/sh -c "PATH=/opt/homebrew/bin:/usr/local/bin:$PATH  brew --prefix"').stdout.chomp
+describe brew_prefix do
+  it { should match('^(\/usr\/local|\/opt\/homebrew)$') }
+end
+
+describe file(brew_prefix) do
+  it { should be_directory }
+end
+
+brew_caskroom = command('/bin/sh -c "PATH=/opt/homebrew/bin:/usr/local/bin:$PATH  brew --caskroom"').stdout.chomp
+describe brew_caskroom do
+  it { should match('^(\/usr\/local|\/opt\/homebrew)/Caskroom$') }
+end
+
+describe file(brew_caskroom) do
+  it { should be_directory }
+end
+
+describe package('redis') do
+  it { should be_installed }
+end
+
+describe package('jq') do
+  it { should be_installed }
+end
+
+# CI agnostic caskroom owner check
+# InSpec may be running commands w/sudo
+ci_user = command('whoami').stdout.chomp
+if ci_user == 'root'
+  ci_user = command("/bin/sh -c 'echo $SUDO_USER'").stdout.chomp
+end
+describe file("#{brew_caskroom}/caffeine") do
   it { should be_directory }
   its('mode') { should cmp '0755' }
-  it { should be_owned_by 'runner' }
+  it { should be_owned_by ci_user }
 end


### PR DESCRIPTION
# Description

 - Adds support for arm64 installation of Homebrew

## Issues Resolved

#153 - Support arm64 install of Homebrew

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable.
