### PR TITLE
Add temporary sudoers entry to fix homebrew installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the homebrew cookbook.
 
 ## Unreleased
 
+- Add temporary sudoers entry to fix homebrew installation
+
 ## 5.3.8 - *2023-04-16*
 
 Standardise files with files in sous-chefs/repo-management

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'homebrew::default' do
   before do
     stubs_for_resource('execute[set analytics]') do |resource|
-      allow(resource).to receive_shell_out('/opt/homebrew/bin/brew analytics state', user: 'vagrant')
-      allow(resource).to receive_shell_out('/opt/homebrew/bin/brew analytics state', user: 'vagrant')
+      allow(resource).to receive_shell_out('/usr/local/bin/brew analytics state', user: 'vagrant')
+      allow(resource).to receive_shell_out('/usr/local/bin/brew analytics state', user: 'vagrant')
     end
 
     allow(Homebrew).to receive(:exist?).and_return(true)

--- a/spec/recipes/install_formulas_spec.rb
+++ b/spec/recipes/install_formulas_spec.rb
@@ -9,7 +9,7 @@ describe 'homebrew::install_formulas' do
 
   before do
     stubs_for_resource('execute[set analytics]') do |resource|
-      allow(resource).to receive_shell_out('/opt/homebrew/bin/brew analytics state', user: 'vagrant')
+      allow(resource).to receive_shell_out('/usr/local/bin/brew analytics state', user: 'vagrant')
     end
     stub_command('which git').and_return('/usr/local/bin/git')
     allow(Homebrew).to receive(:owner).and_return('vagrant')


### PR DESCRIPTION
# Description

The README says "[t]his cookbook installs Homebrew," which isn't exactly true since installing Homebrew requires elevated permissions. This PR adds a `sudo` resource to add a temporary entry to sudoers.d with an allowlist of each binary called by the installation script's `execute_sudo` function. `NONINTERACTIVE` is set as an environment variable to toggle non-interactive installation (added in https://github.com/Homebrew/install/pull/614).

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.


