### PR TITLE
Include `Which` for `HomebrewUserWrapper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 This file is used to list changes made in each version of the homebrew cookbook.
 
-## Unreleased
+## 5.4.6 - *2024-05-06*
+
+- Explicitly include `Which` module from `Chef` which fixes runs on 18.x clients.
+
 
 ## 5.4.5 - *2023-11-01*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ This file is used to list changes made in each version of the homebrew cookbook.
 
 - Explicitly include `Which` module from `Chef` which fixes runs on 18.x clients.
 
-
 ## 5.4.5 - *2023-11-01*
 
 Standardise files with files in sous-chefs/repo-management

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -22,6 +22,7 @@
 class HomebrewUserWrapper
   require 'chef/mixin/homebrew_user'
   include Chef::Mixin::HomebrewUser
+  include Chef::Mixin::Which
 end
 
 module Homebrew

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description      'Install Homebrew and includes resources for working with taps and casks'
-version          '5.4.5'
+version          '5.4.6'
 supports         'mac_os_x'
 
 source_url 'https://github.com/sous-chefs/homebrew'


### PR DESCRIPTION
# Description

Explicitly include `Which` module from `Chef` which fixes cookbook use on newer 18.x clients. 

## Issues Resolved

Fixes #183 

## Check List

- [✅] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [❌] New functionality includes testing.
- [❌] New functionality has been documented in the README if applicable.
