### PR TITLE
chore: use Policyfile dependency resolution

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@
 - `libraries/` - Library helpers to assist with the cookbook. May contain multiple files depending on complexity of the cookbook.
 - `templates/` - ERB templates that may be used in the cookbook
 - `files/` - files that may be used in the cookbook
-- `metadata.rb`, `Berksfile` - Cookbook metadata and dependencies
+- `metadata.rb`, `Policyfile.rb` - Cookbook metadata and dependencies
 
 ## Build and Test System
 
@@ -27,7 +27,7 @@
 
 ### Essential Commands (strict order)
 ```bash
-berks install                   # Install dependencies (always first)
+chef install Policyfile.rb      # Install dependencies (always first)
 cookstyle                       # Ruby/Chef linting
 yamllint .                      # YAML linting
 markdownlint-cli2 '**/*.md'     # Markdown linting
@@ -42,7 +42,7 @@ chef exec rspec                 # Unit tests (ChefSpec)
 - **Full CI Runtime:** 30+ minutes for complete matrix
 
 ### Common Issues and Solutions
-- **Always run `berks install` first** - most failures are dependency-related
+- **Always run `chef install Policyfile.rb` first** - most failures are dependency-related
 - **Docker must be running** for kitchen tests
 - **Chef Workstation required** - no workarounds, no alternatives
 - **Test data bags needed** (optional for some cookbooks) in `test/integration/data_bags/` for convergence
@@ -88,7 +88,7 @@ These instructions are validated for Sous Chefs cookbooks. **Do not search for b
 
 **Error Resolution Checklist:**
 1. Verify Chef Workstation installation
-2. Confirm `berks install` completed successfully
+2. Confirm `chef install Policyfile.rb` completed successfully
 3. Ensure Docker is running for integration tests
 4. Check for missing test data dependencies
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,13 +1,10 @@
-# Policyfile.rb - Describe how you want Chef Infra Client to build your system.
+# frozen_string_literal: true
 
 name 'homebrew'
 
-# Where to find external cookbooks:
 default_source :supermarket
 
-# run_list: chef-client will run these recipes in the order specified.
 run_list 'test::default'
 
-# Specify a custom source for a single cookbook:
 cookbook 'homebrew', path: '.'
 cookbook 'test', path: './test/cookbooks/test'

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 require_relative '../libraries/helpers'
 


### PR DESCRIPTION
## Summary
- move dependency resolution to Policyfile
- remove stale Berkshelf files/references where present
- update Copilot setup/docs to use `chef install Policyfile.rb` where applicable

## Testing
- chef install Policyfile.rb (resolves existing ssh_known_hosts test dependency from Supermarket)
- cookstyle
- chef exec rspec --format documentation: 30 examples, 0 failures